### PR TITLE
Feature : compute effective field atomic loop

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "initio",
         "nonadiabatic",
         "spintronics"
-    ]
+    ],
+    "fortran.fortls.disabled": true
 }


### PR DESCRIPTION
Allow the computation of the effective field for all atoms outside of their loop.
This has to be checked very carefully.
The default behavior is
```fortran
&sd
 compute_effective_field_every = 1
 compute_effective_field_atomic_loop = .true.
```
 